### PR TITLE
Rename boot services' memset to set_mem

### DIFF
--- a/src/data_types/strs.rs
+++ b/src/data_types/strs.rs
@@ -192,7 +192,7 @@ impl fmt::Debug for CStr16 {
 impl fmt::Display for CStr16 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for c in self.iter() {
-            <Char16 as fmt::Display>::fmt(&c, f)?;
+            <Char16 as fmt::Display>::fmt(c, f)?;
         }
         Ok(())
     }

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -526,7 +526,7 @@ impl BootServices {
     ///
     /// This function is unsafe as it can be used to violate most safety
     /// invariants of the Rust type system.
-    pub unsafe fn set_mem(&self, buffer: *mut u8, value: u8, size: usize) {
+    pub unsafe fn set_mem(&self, buffer: *mut u8, size: usize, value: u8) {
         (self.set_mem)(buffer, size, value);
     }
 }

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -526,7 +526,7 @@ impl BootServices {
     ///
     /// This function is unsafe as it can be used to violate most safety
     /// invariants of the Rust type system.
-    pub unsafe fn memset(&self, buffer: *mut u8, size: usize, value: u8) {
+    pub unsafe fn set_mem(&self, buffer: *mut u8, value: u8, size: usize) {
         (self.set_mem)(buffer, size, value);
     }
 }

--- a/uefi-test-runner/src/boot/memory.rs
+++ b/uefi-test-runner/src/boot/memory.rs
@@ -59,16 +59,16 @@ fn alloc_alignment() {
     assert_eq!(value.as_ptr() as usize % 0x100, 0, "Wrong alignment");
 }
 
-// Test that the `memmove` / `memset` functions work.
+// Test that the `memmove` / `set_mem` functions work.
 fn memmove(bt: &BootServices) {
-    info!("Testing the `memmove` / `memset` functions");
+    info!("Testing the `memmove` / `set_mem` functions");
 
     let src = [1, 2, 3, 4];
     let mut dest = [0u8; 4];
 
     // Fill the buffer with a value
     unsafe {
-        bt.memset(dest.as_mut_ptr(), dest.len(), 1);
+        bt.set_mem(dest.as_mut_ptr(), dest.len(), 1);
     }
 
     assert_eq!(dest, [1; 4], "Failed to set memory");

--- a/uefi-test-runner/src/proto/console/gop.rs
+++ b/uefi-test-runner/src/proto/console/gop.rs
@@ -25,7 +25,7 @@ fn set_graphics_mode(gop: &mut GraphicsOutput) {
     let mode = gop
         .modes()
         .map(|mode| mode.expect("Warnings encountered while querying mode"))
-        .find(|ref mode| {
+        .find(|mode| {
             let info = mode.info();
             info.resolution() == (1024, 768)
         })


### PR DESCRIPTION
In boot.rs we see there is an unsafe function named memset. This function has a signature different than memset(3), but has a name different than that in the edk2 sources. This is confusing and will lead to bugs in a very unsafe function when people mix up the order of the value and the size.

We should either name the function memset and give it the libc-style signature memset(&self, buffer: *mut u8, value: u8, size: usize), or name the function set_mem and give it the signature from EFI_SET_MEM.

uefi-rs/src/table/boot.rs

Line 529 in 948464c

 pub unsafe fn memset(&self, buffer: *mut u8, size: usize, value: u8) { 

See https://github.com/rust-osdev/uefi-rs/issues/232